### PR TITLE
docs: add PR approval requirement rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,11 @@ Requires write permissions to run CI.
 - Close issue: `gh issue close <number>`
 
 ### Branches & PRs
+- **NEVER push directly to `main`** - always create a Pull Request for review
 - Always work on a feature branch: `git checkout -b feature/<name>`
 - Push branch and create PR: `gh pr create`
 - Wait for CI to pass: `gh pr checks <number> --watch`
+- **Merge only after developer approval** - never merge your own PR without review
 - Merge PR: `gh pr merge <number> --merge --delete-branch`
 
 ### Releasing a Version


### PR DESCRIPTION
Adds explicit rule that merges require developer approval and direct pushes to main are prohibited.