### PR TITLE
feat: Make SvgRenderer moduleSize configurable via constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `SvgRenderer` now accepts optional `$moduleSize` constructor parameter (default: 10)
+- `InvalidConfigurationException` for configuration validation errors
+
 ### Changed
 
 - Removed `docs/` directory from repository tracking and added to `.gitignore`

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ScanMePHP\Exception;
+
+use Exception;
+
+class InvalidConfigurationException extends Exception
+{
+    public static function invalidModuleSize(int $size): self
+    {
+        return new self(sprintf(
+            'Module size must be greater than 0, got %d',
+            $size
+        ));
+    }
+}

--- a/src/Renderer/SvgRenderer.php
+++ b/src/Renderer/SvgRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ScanMePHP\Renderer;
 
+use ScanMePHP\Exception\InvalidConfigurationException;
 use ScanMePHP\Matrix;
 use ScanMePHP\ModuleStyle;
 use ScanMePHP\RenderOptions;
@@ -11,7 +12,13 @@ use ScanMePHP\RendererInterface;
 
 class SvgRenderer implements RendererInterface
 {
-    private int $moduleSize = 10;
+    public function __construct(
+        private readonly int $moduleSize = 10,
+    ) {
+        if ($this->moduleSize <= 0) {
+            throw InvalidConfigurationException::invalidModuleSize($this->moduleSize);
+        }
+    }
 
     public function getContentType(): string
     {

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -12,6 +12,7 @@ use ScanMePHP\Renderer\SvgRenderer;
 use ScanMePHP\Renderer\HtmlDivRenderer;
 use ScanMePHP\Renderer\HtmlTableRenderer;
 use ScanMePHP\ErrorCorrectionLevel;
+use ScanMePHP\Exception\InvalidConfigurationException;
 use ScanMePHP\ModuleStyle;
 
 class QRCodeTest extends TestCase
@@ -254,5 +255,44 @@ class QRCodeTest extends TestCase
         $output = $qr->render();
 
         $this->assertStringContainsString('Test Label', $output);
+    }
+
+    public function testSvgRendererCustomModuleSize(): void
+    {
+        $config = new QRCodeConfig(engine: new SvgRenderer(moduleSize: 20));
+        $qr = new QRCode('https://example.com', $config);
+        $output = $qr->render();
+
+        $this->assertIsString($output);
+        $this->assertStringContainsString('width="', $output);
+        // With moduleSize=20 and default margin=4, total size should be larger
+        $this->assertStringContainsString('viewBox="0 0 ', $output);
+    }
+
+    public function testSvgRendererDefaultModuleSize(): void
+    {
+        // Default moduleSize is 10
+        $config = new QRCodeConfig(engine: new SvgRenderer());
+        $qr = new QRCode('https://example.com', $config);
+        $output = $qr->render();
+
+        $this->assertIsString($output);
+        $this->assertStringContainsString('<?xml', $output);
+    }
+
+    public function testSvgRendererInvalidModuleSize(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Module size must be greater than 0');
+
+        new SvgRenderer(moduleSize: 0);
+    }
+
+    public function testSvgRendererNegativeModuleSize(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Module size must be greater than 0');
+
+        new SvgRenderer(moduleSize: -5);
     }
 }


### PR DESCRIPTION
## Summary

This PR makes the `moduleSize` parameter in `SvgRenderer` configurable via the constructor, as requested in #5.

## Changes

- **SvgRenderer**: Added optional `$moduleSize` constructor parameter (default: 10)
- **Validation**: Throws `InvalidConfigurationException` when moduleSize ≤ 0
- **New Exception**: `InvalidConfigurationException` for configuration validation errors
- **Tests**: Added 4 new test cases covering custom size, default value, and invalid inputs
- **CHANGELOG**: Updated under [Unreleased]

## Usage

```php
// Default module size (10)
$renderer = new SvgRenderer();

// Custom module size
$renderer = new SvgRenderer(moduleSize: 20);
$config = new QRCodeConfig(engine: $renderer);
$qr = new QRCode('https://example.com', $config);
```

## Testing

All 38 tests pass, including 4 new tests for this feature.

Closes #5