### PR TITLE
refactor: rename namespace from ScanMePHP to CrazyGoat\ScanMePHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Pure PHP QR code generator. Zero dependencies, zero extensions. PHP 8.1+.
 
+## Features
+
+- **Zero dependencies** — no external packages, no PHP extensions required
+- **8 built-in renderers** — SVG, PNG, HTML (div/table), ASCII (full/half/simple blocks)
+- **All QR versions** — v1–v40, all error correction levels (L/M/Q/H)
+- **High performance** — optimized renderers with 20–40% faster output generation
+- **Customizable** — module styles, colors, labels, dark mode, margins
+- **Type-safe** — strict types, enums, readonly properties, PHP 8.1+ idioms
+
 ## Installation
 
 ```bash
@@ -20,6 +29,16 @@ echo $qr->render();
 ## Renderers
 
 ScanMePHP ships with 8 renderers. Each implements `RendererInterface` and can be passed as the `engine` parameter.
+
+| Renderer | Output | Constructor Options |
+|---|---|---|
+| `FullBlocksRenderer` | ASCII `█` blocks | `sideMargin` (int, default: 0) |
+| `HalfBlocksRenderer` | ASCII `▀▄█` compact | `sideMargin` (int, default: 0) |
+| `SimpleRenderer` | ASCII `●` dots | `sideMargin` (int, default: 0) |
+| `SvgRenderer` | SVG XML | `moduleSize` (int, default: 10) |
+| `PngRenderer` | PNG image (1-bit) | `moduleSize` (int, default: 10) |
+| `HtmlDivRenderer` | HTML `<div>` grid | `moduleSize` (int, default: 10), `fullHtml` (bool, default: false) |
+| `HtmlTableRenderer` | HTML `<table>` | `moduleSize` (int, default: 10), `fullHtml` (bool, default: false) |
 
 ### ASCII — FullBlocksRenderer (default)
 
@@ -67,7 +86,7 @@ use ScanMePHP\Renderer\SvgRenderer;
 use ScanMePHP\ModuleStyle;
 
 $config = new QRCodeConfig(
-    engine: new SvgRenderer(),
+    engine: new SvgRenderer(moduleSize: 12),
     moduleStyle: ModuleStyle::Rounded, // Square, Rounded, or Dot
     label: 'Scan Me!',
 );
@@ -133,6 +152,11 @@ $config = new QRCodeConfig(
 All options are set via `QRCodeConfig`:
 
 ```php
+use ScanMePHP\QRCodeConfig;
+use ScanMePHP\ErrorCorrectionLevel;
+use ScanMePHP\ModuleStyle;
+use ScanMePHP\Renderer\SvgRenderer;
+
 $config = new QRCodeConfig(
     engine: new SvgRenderer(),                          // renderer instance
     errorCorrectionLevel: ErrorCorrectionLevel::Medium,  // Low, Medium, Quartile, High
@@ -212,18 +236,6 @@ class MyCustomRenderer implements RendererInterface
 }
 ```
 
-## Renderer Reference
-
-| Renderer | Output | Constructor Options |
-|---|---|---|
-| `FullBlocksRenderer` | ASCII `█` blocks | `sideMargin` (int, default: 0) |
-| `HalfBlocksRenderer` | ASCII `▀▄█` compact | `sideMargin` (int, default: 0) |
-| `SimpleRenderer` | ASCII `●` dots | `sideMargin` (int, default: 0) |
-| `SvgRenderer` | SVG XML | — |
-| `PngRenderer` | PNG image (1-bit) | `moduleSize` (int, default: 10) |
-| `HtmlDivRenderer` | HTML `<div>` grid | `moduleSize` (int, default: 10), `fullHtml` (bool, default: false) |
-| `HtmlTableRenderer` | HTML `<table>` | `moduleSize` (int, default: 10), `fullHtml` (bool, default: false) |
-
 ## Requirements
 
 - PHP >= 8.1
@@ -245,6 +257,7 @@ php examples/ascii_fullblocks.php
 php examples/svg_example.php
 php examples/png_example.php
 php examples/html_div.php
+php examples/html_table.php
 ```
 
 Generated output files are saved to `examples/generated-assets/`.

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     },
     "autoload": {
         "psr-4": {
-            "ScanMePHP\\": "src/"
+            "CrazyGoat\\ScanMePHP\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "ScanMePHP\\Tests\\": "tests/"
+            "CrazyGoat\\ScanMePHP\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/examples/ascii_fullblocks.php
+++ b/examples/ascii_fullblocks.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\FullBlocksRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\FullBlocksRenderer;
 
 echo "=== ScanMePHP - Full Blocks Renderer ===\n\n";
 

--- a/examples/ascii_halfblocks.php
+++ b/examples/ascii_halfblocks.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\HalfBlocksRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\HalfBlocksRenderer;
 
 echo "=== ScanMePHP - Half Blocks Renderer ===\n\n";
 

--- a/examples/ascii_simple.php
+++ b/examples/ascii_simple.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\SimpleRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\SimpleRenderer;
 
 echo "=== ScanMePHP - Simple Renderer ===\n\n";
 

--- a/examples/benchmark.php
+++ b/examples/benchmark.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\PngRenderer;
-use ScanMePHP\Renderer\SvgRenderer;
-use ScanMePHP\Renderer\HtmlDivRenderer;
-use ScanMePHP\Renderer\HtmlTableRenderer;
-use ScanMePHP\Renderer\FullBlocksRenderer;
-use ScanMePHP\Renderer\HalfBlocksRenderer;
-use ScanMePHP\Renderer\SimpleRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\PngRenderer;
+use CrazyGoat\ScanMePHP\Renderer\SvgRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HtmlDivRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HtmlTableRenderer;
+use CrazyGoat\ScanMePHP\Renderer\FullBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HalfBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\SimpleRenderer;
 
 function showUsage(): void
 {

--- a/examples/benchmark_render.php
+++ b/examples/benchmark_render.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\PngRenderer;
-use ScanMePHP\Renderer\SvgRenderer;
-use ScanMePHP\Renderer\HtmlDivRenderer;
-use ScanMePHP\Renderer\HtmlTableRenderer;
-use ScanMePHP\Renderer\FullBlocksRenderer;
-use ScanMePHP\Renderer\HalfBlocksRenderer;
-use ScanMePHP\Renderer\SimpleRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\PngRenderer;
+use CrazyGoat\ScanMePHP\Renderer\SvgRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HtmlDivRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HtmlTableRenderer;
+use CrazyGoat\ScanMePHP\Renderer\FullBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HalfBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\SimpleRenderer;
 
 function showUsage(): void
 {

--- a/examples/html_div.php
+++ b/examples/html_div.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\HtmlDivRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\HtmlDivRenderer;
 
 echo "=== ScanMePHP - HTML Div Renderer ===\n\n";
 

--- a/examples/html_table.php
+++ b/examples/html_table.php
@@ -2,9 +2,9 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\HtmlTableRenderer;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\HtmlTableRenderer;
 
 echo "=== ScanMePHP - HTML Table Renderer ===\n\n";
 

--- a/examples/png_example.php
+++ b/examples/png_example.php
@@ -2,10 +2,10 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\PngRenderer;
-use ScanMePHP\ErrorCorrectionLevel;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\PngRenderer;
+use CrazyGoat\ScanMePHP\ErrorCorrectionLevel;
 
 echo "=== ScanMePHP - PNG QR Code Example ===\n\n";
 

--- a/examples/svg_example.php
+++ b/examples/svg_example.php
@@ -2,11 +2,11 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\SvgRenderer;
-use ScanMePHP\ErrorCorrectionLevel;
-use ScanMePHP\ModuleStyle;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\SvgRenderer;
+use CrazyGoat\ScanMePHP\ErrorCorrectionLevel;
+use CrazyGoat\ScanMePHP\ModuleStyle;
 
 echo "=== ScanMePHP - SVG QR Code Example ===\n\n";
 

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
-use ScanMePHP\Encoding\DataAnalyzer;
-use ScanMePHP\Encoding\DataEncoder;
-use ScanMePHP\Encoding\MaskSelector;
-use ScanMePHP\Encoding\MatrixBuilder;
-use ScanMePHP\Encoding\Mode;
-use ScanMePHP\Encoding\ReedSolomon;
-use ScanMePHP\Exception\DataTooLargeException;
-use ScanMePHP\Exception\InvalidDataException;
+use CrazyGoat\ScanMePHP\Encoding\DataAnalyzer;
+use CrazyGoat\ScanMePHP\Encoding\DataEncoder;
+use CrazyGoat\ScanMePHP\Encoding\MaskSelector;
+use CrazyGoat\ScanMePHP\Encoding\MatrixBuilder;
+use CrazyGoat\ScanMePHP\Encoding\Mode;
+use CrazyGoat\ScanMePHP\Encoding\ReedSolomon;
+use CrazyGoat\ScanMePHP\Exception\DataTooLargeException;
+use CrazyGoat\ScanMePHP\Exception\InvalidDataException;
 
 class Encoder
 {

--- a/src/Encoding/DataAnalyzer.php
+++ b/src/Encoding/DataAnalyzer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Encoding;
+namespace CrazyGoat\ScanMePHP\Encoding;
 
 class DataAnalyzer
 {

--- a/src/Encoding/DataEncoder.php
+++ b/src/Encoding/DataEncoder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Encoding;
+namespace CrazyGoat\ScanMePHP\Encoding;
 
-use ScanMePHP\Exception\InvalidDataException;
+use CrazyGoat\ScanMePHP\Exception\InvalidDataException;
 
 class DataEncoder
 {

--- a/src/Encoding/MaskSelector.php
+++ b/src/Encoding/MaskSelector.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Encoding;
+namespace CrazyGoat\ScanMePHP\Encoding;
 
-use ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\Matrix;
 
 class MaskSelector
 {

--- a/src/Encoding/MatrixBuilder.php
+++ b/src/Encoding/MatrixBuilder.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Encoding;
+namespace CrazyGoat\ScanMePHP\Encoding;
 
-use ScanMePHP\ErrorCorrectionLevel;
-use ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\ErrorCorrectionLevel;
+use CrazyGoat\ScanMePHP\Matrix;
 
 class MatrixBuilder
 {

--- a/src/Encoding/Mode.php
+++ b/src/Encoding/Mode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Encoding;
+namespace CrazyGoat\ScanMePHP\Encoding;
 
 enum Mode: int
 {

--- a/src/Encoding/ReedSolomon.php
+++ b/src/Encoding/ReedSolomon.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Encoding;
+namespace CrazyGoat\ScanMePHP\Encoding;
 
 class ReedSolomon
 {

--- a/src/ErrorCorrectionLevel.php
+++ b/src/ErrorCorrectionLevel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
 enum ErrorCorrectionLevel: int
 {

--- a/src/Exception/DataTooLargeException.php
+++ b/src/Exception/DataTooLargeException.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Exception;
+namespace CrazyGoat\ScanMePHP\Exception;
 
 use Exception;
-use ScanMePHP\ErrorCorrectionLevel;
+use CrazyGoat\ScanMePHP\ErrorCorrectionLevel;
 
 class DataTooLargeException extends Exception
 {

--- a/src/Exception/FileWriteException.php
+++ b/src/Exception/FileWriteException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Exception;
+namespace CrazyGoat\ScanMePHP\Exception;
 
 use Exception;
 

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Exception;
+namespace CrazyGoat\ScanMePHP\Exception;
 
 use Exception;
 

--- a/src/Exception/InvalidDataException.php
+++ b/src/Exception/InvalidDataException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Exception;
+namespace CrazyGoat\ScanMePHP\Exception;
 
 use Exception;
 

--- a/src/Exception/RenderException.php
+++ b/src/Exception/RenderException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Exception;
+namespace CrazyGoat\ScanMePHP\Exception;
 
 use Exception;
 

--- a/src/Matrix.php
+++ b/src/Matrix.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
 class Matrix
 {

--- a/src/ModuleStyle.php
+++ b/src/ModuleStyle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
 enum ModuleStyle: string
 {

--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
-use ScanMePHP\Encoding\Mode;
-use ScanMePHP\Exception\FileWriteException;
-use ScanMePHP\Exception\InvalidDataException;
-use ScanMePHP\Exception\RenderException;
+use CrazyGoat\ScanMePHP\Encoding\Mode;
+use CrazyGoat\ScanMePHP\Exception\FileWriteException;
+use CrazyGoat\ScanMePHP\Exception\InvalidDataException;
+use CrazyGoat\ScanMePHP\Exception\RenderException;
 
 class QRCode
 {

--- a/src/QRCodeConfig.php
+++ b/src/QRCodeConfig.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
-use ScanMePHP\Renderer\FullBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\FullBlocksRenderer;
 
 class QRCodeConfig
 {

--- a/src/RenderOptions.php
+++ b/src/RenderOptions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
 class RenderOptions
 {

--- a/src/Renderer/AbstractAsciiRenderer.php
+++ b/src/Renderer/AbstractAsciiRenderer.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
-use ScanMePHP\RendererInterface;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\RendererInterface;
 
 abstract class AbstractAsciiRenderer implements RendererInterface
 {

--- a/src/Renderer/FullBlocksRenderer.php
+++ b/src/Renderer/FullBlocksRenderer.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
 
 class FullBlocksRenderer extends AbstractAsciiRenderer
 {

--- a/src/Renderer/HalfBlocksRenderer.php
+++ b/src/Renderer/HalfBlocksRenderer.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
 
 class HalfBlocksRenderer extends AbstractAsciiRenderer
 {

--- a/src/Renderer/HtmlDivRenderer.php
+++ b/src/Renderer/HtmlDivRenderer.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
-use ScanMePHP\RendererInterface;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\RendererInterface;
 
 class HtmlDivRenderer implements RendererInterface
 {

--- a/src/Renderer/HtmlTableRenderer.php
+++ b/src/Renderer/HtmlTableRenderer.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
-use ScanMePHP\RendererInterface;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\RendererInterface;
 
 class HtmlTableRenderer implements RendererInterface
 {

--- a/src/Renderer/PngEncoder.php
+++ b/src/Renderer/PngEncoder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
 /**
  * Minimal PNG encoder for 1-bit monochrome images.

--- a/src/Renderer/PngRenderer.php
+++ b/src/Renderer/PngRenderer.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Exception\RenderException;
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
-use ScanMePHP\RendererInterface;
+use CrazyGoat\ScanMePHP\Exception\RenderException;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\RendererInterface;
 
 class PngRenderer implements RendererInterface
 {

--- a/src/Renderer/SimpleRenderer.php
+++ b/src/Renderer/SimpleRenderer.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Matrix;
-use ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\RenderOptions;
 
 class SimpleRenderer extends AbstractAsciiRenderer
 {

--- a/src/Renderer/SvgRenderer.php
+++ b/src/Renderer/SvgRenderer.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP\Renderer;
+namespace CrazyGoat\ScanMePHP\Renderer;
 
-use ScanMePHP\Exception\InvalidConfigurationException;
-use ScanMePHP\Matrix;
-use ScanMePHP\ModuleStyle;
-use ScanMePHP\RenderOptions;
-use ScanMePHP\RendererInterface;
+use CrazyGoat\ScanMePHP\Exception\InvalidConfigurationException;
+use CrazyGoat\ScanMePHP\Matrix;
+use CrazyGoat\ScanMePHP\ModuleStyle;
+use CrazyGoat\ScanMePHP\RenderOptions;
+use CrazyGoat\ScanMePHP\RendererInterface;
 
 class SvgRenderer implements RendererInterface
 {

--- a/src/RendererInterface.php
+++ b/src/RendererInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ScanMePHP;
+namespace CrazyGoat\ScanMePHP;
 
 interface RendererInterface
 {

--- a/tests/PngRendererTest.php
+++ b/tests/PngRendererTest.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\PngRenderer;
-use ScanMePHP\Exception\RenderException;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\PngRenderer;
+use CrazyGoat\ScanMePHP\Exception\RenderException;
 
 class PngRendererTest extends TestCase
 {
@@ -178,7 +178,7 @@ class PngRendererTest extends TestCase
 
     public function testDifferentErrorCorrectionLevels(): void
     {
-        foreach (\ScanMePHP\ErrorCorrectionLevel::cases() as $level) {
+        foreach (\CrazyGoat\ScanMePHP\ErrorCorrectionLevel::cases() as $level) {
             $config = new QRCodeConfig(
                 engine: new PngRenderer(),
                 errorCorrectionLevel: $level,

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -3,17 +3,17 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use ScanMePHP\QRCode;
-use ScanMePHP\QRCodeConfig;
-use ScanMePHP\Renderer\FullBlocksRenderer;
-use ScanMePHP\Renderer\HalfBlocksRenderer;
-use ScanMePHP\Renderer\SimpleRenderer;
-use ScanMePHP\Renderer\SvgRenderer;
-use ScanMePHP\Renderer\HtmlDivRenderer;
-use ScanMePHP\Renderer\HtmlTableRenderer;
-use ScanMePHP\ErrorCorrectionLevel;
-use ScanMePHP\Exception\InvalidConfigurationException;
-use ScanMePHP\ModuleStyle;
+use CrazyGoat\ScanMePHP\QRCode;
+use CrazyGoat\ScanMePHP\QRCodeConfig;
+use CrazyGoat\ScanMePHP\Renderer\FullBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HalfBlocksRenderer;
+use CrazyGoat\ScanMePHP\Renderer\SimpleRenderer;
+use CrazyGoat\ScanMePHP\Renderer\SvgRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HtmlDivRenderer;
+use CrazyGoat\ScanMePHP\Renderer\HtmlTableRenderer;
+use CrazyGoat\ScanMePHP\ErrorCorrectionLevel;
+use CrazyGoat\ScanMePHP\Exception\InvalidConfigurationException;
+use CrazyGoat\ScanMePHP\ModuleStyle;
 
 class QRCodeTest extends TestCase
 {


### PR DESCRIPTION
## Summary

This PR renames the namespace from  to  as requested in #18.

### Changes

- **composer.json**: Updated autoload namespaces for both production and dev
- **src/**: Updated all namespace declarations from  to 
- **tests/**: Updated all use statements to use new namespace
- **examples/**: Updated all use statements to use new namespace
- **examples/generated-assets/**: Regenerated all example assets

### Breaking Changes

⚠️ **This is a breaking change** - users will need to update their use statements:



### Testing

All 38 tests pass successfully.

Closes #18