### PR TITLE
fix: respect invert option in PngRenderer

### DIFF
--- a/src/Renderer/PngRenderer.php
+++ b/src/Renderer/PngRenderer.php
@@ -36,10 +36,11 @@ class PngRenderer implements RendererInterface
         $margin = $options->margin;
         $totalModules = $size + (2 * $margin);
         $totalPixels = $totalModules * $this->moduleSize;
+        $invert = $options->invert;
 
         return $this->encoder->encodeStreaming(
-            function (int $y) use ($matrix, $size, $margin, $totalModules): array {
-                return $this->buildScanline($matrix, $size, $margin, $totalModules, $y);
+            function (int $y) use ($matrix, $size, $margin, $totalModules, $invert): array {
+                return $this->buildScanline($matrix, $size, $margin, $totalModules, $y, $invert);
             },
             $totalPixels,
             $totalPixels
@@ -52,7 +53,7 @@ class PngRenderer implements RendererInterface
      *
      * @return bool[] Array of boolean pixel values for this row
      */
-    private function buildScanline(Matrix $matrix, int $size, int $margin, int $totalModules, int $pixelY): array
+    private function buildScanline(Matrix $matrix, int $size, int $margin, int $totalModules, int $pixelY, bool $invert): array
     {
         $mod = $this->moduleSize;
         $moduleY = (int) ($pixelY / $mod);
@@ -64,6 +65,10 @@ class PngRenderer implements RendererInterface
             $isDark = ($dataX >= 0 && $dataX < $size && $dataY >= 0 && $dataY < $size)
                 ? $matrix->get($dataX, $dataY)
                 : false;
+
+            if ($invert) {
+                $isDark = !$isDark;
+            }
 
             // Expand this module to moduleSize pixels
             for ($px = 0; $px < $mod; $px++) {

--- a/tests/PngRendererTest.php
+++ b/tests/PngRendererTest.php
@@ -231,4 +231,60 @@ class PngRendererTest extends TestCase
 
         imagedestroy($image);
     }
+
+    public function testInvertProducesDifferentOutputThanNormal(): void
+    {
+        $config = new QRCodeConfig(engine: new PngRenderer());
+        $qr = new QRCode('https://example.com', $config);
+        $normal = $qr->render();
+
+        $configInverted = new QRCodeConfig(engine: new PngRenderer(), invert: true);
+        $qrInverted = new QRCode('https://example.com', $configInverted);
+        $inverted = $qrInverted->render();
+
+        $this->assertNotEquals($normal, $inverted, 'Inverted PNG should differ from normal PNG');
+    }
+
+    public function testInvertSwapsPixelColors(): void
+    {
+        if (!extension_loaded('gd')) {
+            $this->markTestSkipped('GD extension not available for validation');
+        }
+
+        $config = new QRCodeConfig(engine: new PngRenderer(moduleSize: 1), margin: 0);
+        $qr = new QRCode('https://example.com', $config);
+
+        $configInverted = new QRCodeConfig(engine: new PngRenderer(moduleSize: 1), margin: 0, invert: true);
+        $qrInverted = new QRCode('https://example.com', $configInverted);
+
+        $image = imagecreatefromstring($qr->render());
+        $imageInverted = imagecreatefromstring($qrInverted->render());
+
+        $this->assertNotFalse($image);
+        $this->assertNotFalse($imageInverted);
+
+        $matrix = $qr->getMatrix();
+        $size = $matrix->getSize();
+
+        for ($y = 0; $y < $size; $y += 5) {
+            for ($x = 0; $x < $size; $x += 5) {
+                $isDark = $matrix->get($x, $y);
+
+                $colorNormal = imagecolorsforindex($image, imagecolorat($image, $x, $y));
+                $colorInverted = imagecolorsforindex($imageInverted, imagecolorat($imageInverted, $x, $y));
+
+                $isNormalDark = $colorNormal['red'] <= 128;
+                $isInvertedDark = $colorInverted['red'] <= 128;
+
+                $this->assertNotEquals(
+                    $isNormalDark,
+                    $isInvertedDark,
+                    "Pixel ($x,$y) should be inverted: normal=" . ($isNormalDark ? 'dark' : 'light') . ", inverted=" . ($isInvertedDark ? 'dark' : 'light')
+                );
+            }
+        }
+
+        imagedestroy($image);
+        imagedestroy($imageInverted);
+    }
 }


### PR DESCRIPTION
## Summary

- `PngRenderer` was ignoring `RenderOptions::$invert`, producing identical output regardless of the flag
- SVG renderer was already correct (uses `getEffectiveForegroundColor()`/`getEffectiveBackgroundColor()`)
- Added `$invert` parameter to `buildScanline()` which negates `$isDark` when set

## Tests

- `testInvertProducesDifferentOutputThanNormal` — verifies inverted PNG differs from normal
- `testInvertSwapsPixelColors` — verifies each pixel is the opposite color when inverted (requires GD)

Closes #32